### PR TITLE
Return exit code from quarto.run

### DIFF
--- a/quarto_cli/quarto.py
+++ b/quarto_cli/quarto.py
@@ -4,4 +4,4 @@ import subprocess as sp
 
 def run():
 	command = os.path.join(os.path.dirname(__file__), "bin", "quarto")
-	sp.call([command] + sys.argv[1:])
+	return sp.call([command] + sys.argv[1:])


### PR DESCRIPTION
Currently, it appears if you `pip install quarto-cli`, then quarto does not set any error code other than 0.

It looks like this is because the python wrapper which launches the quarto executable does not forward the error codes from the subprocess. Adding a simple return seems to fix this for me.

I believe this would close https://github.com/quarto-dev/quarto-cli/issues/11296