### PR TITLE
Update publish workflow actions for Node 20 deprecation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.x"
       - name: Install pypa/build
@@ -39,10 +39,10 @@ jobs:
       - name: Clean Wheel
         run: rm -rf dist/quarto_cli*.whl
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         if: ${{ ! inputs.publish-release }}
         with:
           repository-url: https://test.pypi.org/legacy/
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         if: ${{ inputs.publish-release }}


### PR DESCRIPTION
GitHub is deprecating Node 20 as a JavaScript actions runtime: Node 24 becomes the forced default on June 2, 2026, and Node 20 is removed on September 16, 2026 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

Bump the publish workflow to the first node24-compatible majors and pin every action by full commit SHA:

- `actions/checkout` v4 → v6.0.2
- `actions/setup-python` v5 → v6.2.0
- `pypa/gh-action-pypi-publish` `release/v1` → v1.14.0

Both `checkout@v6` and `setup-python@v6` declare `using: node24` in `action.yml`. `gh-action-pypi-publish@v1.14.0` is a composite action and unaffected by the runner deprecation, but pinned by SHA for consistency.

## Test Plan

- [x] Manually dispatch with `publish-release: false` and confirm no Node 20 deprecation warnings on the three updated steps
- [x] Verify TestPyPI publish step still succeeds end-to-end