### PR TITLE
fix: exit cleanly on Ctrl+C

### DIFF
--- a/quarto_cli/quarto.py
+++ b/quarto_cli/quarto.py
@@ -4,4 +4,7 @@ import subprocess as sp
 
 def run():
 	command = os.path.join(os.path.dirname(__file__), "bin", "quarto")
-	return sp.call([command] + sys.argv[1:])
+	try:
+		return sp.call([command] + sys.argv[1:])
+	except KeyboardInterrupt:
+		sys.exit(130)


### PR DESCRIPTION
When pressing Ctrl+C to stop a running `quarto` command, a `KeyboardInterrupt` traceback is printed instead of a clean exit.

`sp.call()` raises `KeyboardInterrupt` when the process receives SIGINT; catching it and calling `sys.exit(130)` (the conventional exit code for Ctrl+C) suppresses the traceback.

Reported in https://github.com/orgs/quarto-dev/discussions/14272